### PR TITLE
fortran 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Runs Fortran code from the Node.js side.
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
+
 ## :sparkles: Related
 
  - [`node.fortran`](https://github.com/IonicaBizau/node.fortran#readme)—Execute Node.js in your Fortran programs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fortran",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fortran bridge for Node.js which allows you to run Fortran code from Node.js.",
   "main": "lib/index.js",
   "directories": {
@@ -65,5 +65,17 @@
   "bugs": {
     "url": "https://github.com/IonicaBizau/node-fortran/issues"
   },
-  "homepage": "https://github.com/IonicaBizau/node-fortran"
+  "homepage": "https://github.com/IonicaBizau/node-fortran",
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "scripts/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.